### PR TITLE
Test flatten option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ jobs:
       script:
         - cd tests && python3 -m unittest test.TestYosysScript
 
+      name: "Test :flatten: option"
+      script:
+        - cd tests && python3 -m unittest test.TestFlatten
+
     - stage: Tests
       name: "Test verilog_diagram_yosys config variable"
       script:

--- a/sphinxcontrib_hdl_diagrams/__init__.py
+++ b/sphinxcontrib_hdl_diagrams/__init__.py
@@ -465,18 +465,13 @@ def render_diagram_html(
         if alt is None:
             alt = node.get('alt', self.encode(code).strip())
         imgcss = imgcls and 'class="%s"' % imgcls or ''
-        if format == 'svg':
-            svgtag = '''<object data="%s" type="image/svg+xml">
-            <p class="warning">%s</p></object>\n''' % (fname, alt)
-            self.body.append(svgtag)
-        else:
-            if 'align' in node:
-                self.body.append('<div align="%s" class="align-%s">' %
-                                 (node['align'], node['align']))
-            self.body.append('<img src="%s" alt="%s" %s/>\n' %
-                             (fname, alt, imgcss))
-            if 'align' in node:
-                self.body.append('</div>\n')
+        if 'align' in node:
+            self.body.append('<div align="%s" class="align-%s">' %
+                             (node['align'], node['align']))
+        self.body.append('<img src="%s" alt="%s" %s/>\n' %
+                         (fname, alt, imgcss))
+        if 'align' in node:
+            self.body.append('</div>\n')
 
     raise nodes.SkipNode
 

--- a/tests/code/verilog/fullAdder.v
+++ b/tests/code/verilog/fullAdder.v
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`include "halfAdder.v"
+
+module fullAdder (
+  output wire cout, s,
+  input wire cin, x, y
+);
+  wire c1, c2, s1;
+
+  halfAdder h1(c1, s1, x, y);
+  halfAdder h2(c2, s, cin, s1);
+
+  assign cout = c1 | c2;
+
+endmodule

--- a/tests/code/verilog/halfAdder.v
+++ b/tests/code/verilog/halfAdder.v
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module halfAdder (
+  output wire c, s,
+  input wire x, y
+);
+
+  assign s = x ^ y;
+  assign c = x & y;
+
+endmodule

--- a/tests/test.py
+++ b/tests/test.py
@@ -117,6 +117,7 @@ class TestYosysScript(TestBase):
             app = Sphinx(buildername="html", warningiserror=True, **sphinx_dirs)
             app.build(force_all=True)
 
+
 class TestYosysType(TestBase):
 
     TEST_CASE_NAME = "TestYowasp"
@@ -190,6 +191,7 @@ class TestYosysType(TestBase):
             app = Sphinx(buildername="html", warningiserror=True, **sphinx_dirs)
             app.build(force_all=True)
 
+
 class TestNMigen(TestBase):
 
     TEST_CASE_NAME = "TestNMigen"
@@ -215,6 +217,7 @@ class TestNMigen(TestBase):
         with docutils_namespace():
             app = Sphinx(buildername="html", warningiserror=True, **sphinx_dirs)
             app.build(force_all=True)
+
 
 class TestRTLIL(TestBase):
 
@@ -262,6 +265,34 @@ class TestCompat(TestBase):
 extensions = [
     'sphinxcontrib_verilog_diagrams',
 ]"""
+        }
+
+        self.prepare_test(TEST_NAME, TEST_BUILD_DIR, TEST_FILES, **TEST_JINJA_DICT)
+
+        # Run the Sphinx
+        sphinx_dirs = get_sphinx_dirs(TEST_BUILD_DIR)
+        with docutils_namespace():
+            app = Sphinx(buildername="html", warningiserror=True, **sphinx_dirs)
+            app.build(force_all=True)
+
+
+class TestFlatten(TestBase):
+
+    TEST_CASE_NAME = "TestFlatten"
+    TEST_CASE_BUILD_DIR = os.path.join("build", TEST_CASE_NAME)
+
+    def test_yosys_script(self):
+        TEST_NAME = "test_flatten"
+        TEST_BUILD_DIR = os.path.join("build", self.TEST_CASE_NAME, TEST_NAME)
+        TEST_FILES = [
+            "test_flatten/test_flatten.rst",
+            "code/verilog/fullAdder.v",
+            "code/verilog/halfAdder.v"
+        ]
+        TEST_JINJA_DICT = {
+            "hdl_diagrams_path": "'{}'".format(HDL_DIAGRAMS_PATH),
+            "master_doc": "'test_flatten'",
+            "custom_variables": ""
         }
 
         self.prepare_test(TEST_NAME, TEST_BUILD_DIR, TEST_FILES, **TEST_JINJA_DICT)

--- a/tests/test_flatten/test_flatten.rst
+++ b/tests/test_flatten/test_flatten.rst
@@ -1,0 +1,119 @@
+Test Flatten Option
+===================
+
+This test checks whether a ``:flatten:`` option in the ``hdl-diagram``
+directive works as intended. The ``:flatten:`` option is used to resolve
+the black boxes created by Yosys in place of instantiated modules.
+With this option enabled Yosys will convert everything into low-level logic
+where only basic logic cells and basic FPGA primitives will be used.
+
+Netlistsvg Diagram
+------------------
+
+Here is the diagram of a half-adder with its RST code::
+
+   .. hdl-diagram:: halfAdder.v
+      :type: netlistsvg
+      :module: halfAdder
+
+.. hdl-diagram:: halfAdder.v
+   :type: netlistsvg
+   :module: halfAdder
+
+The diagram below has been created without the ``:flatten:`` option::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: netlistsvg
+      :module: fullAdder
+
+.. hdl-diagram:: fullAdder.v
+   :type: netlistsvg
+   :module: fullAdder
+
+The diagram below has been created using the ``:flatten:`` option.
+You can see that the ``halfAdder`` black box is substituted by the appropriate
+logic elements::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: netlistsvg
+      :module: fullAdder
+      :flatten:
+
+.. hdl-diagram:: fullAdder.v
+   :type: netlistsvg
+   :module: fullAdder
+   :flatten:
+
+Yosys BlackBox Diagram
+----------------------
+
+Here is the diagram of a half-adder with its RST code::
+
+   .. hdl-diagram:: halfAdder.v
+      :type: yosys-blackbox
+      :module: halfAdder
+
+.. hdl-diagram:: halfAdder.v
+   :type: yosys-blackbox
+   :module: halfAdder
+
+The diagram below has been created without the ``:flatten:`` option::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: yosys-blackbox
+      :module: fullAdder
+
+.. hdl-diagram:: fullAdder.v
+   :type: yosys-blackbox
+   :module: fullAdder
+
+The diagram below has been created using the ``:flatten:`` option.
+You can see that the ``halfAdder`` black box is substituted by the appropriate
+logic elements::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: yosys-blackbox
+      :module: fullAdder
+      :flatten:
+
+.. hdl-diagram:: fullAdder.v
+   :type: yosys-blackbox
+   :module: fullAdder
+   :flatten:
+
+Yosys AIG Diagram
+-----------------
+
+Here is the diagram of a half-adder with its RST code::
+
+   .. hdl-diagram:: halfAdder.v
+      :type: yosys-aig
+      :module: halfAdder
+
+.. hdl-diagram:: halfAdder.v
+   :type: yosys-aig
+   :module: halfAdder
+
+The diagram below has been created without the ``:flatten:`` option::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: yosys-aig
+      :module: fullAdder
+
+.. hdl-diagram:: fullAdder.v
+   :type: yosys-aig
+   :module: fullAdder
+
+The diagram below has been created using the ``:flatten:`` option.
+You can see that the ``halfAdder`` black box is substituted by the appropriate
+logic elements::
+
+   .. hdl-diagram:: fullAdder.v
+      :type: yosys-aig
+      :module: fullAdder
+      :flatten:
+
+.. hdl-diagram:: fullAdder.v
+   :type: yosys-aig
+   :module: fullAdder
+   :flatten:


### PR DESCRIPTION
This PR adds the basic tests for the flatten option in the verilog-diagram directive. The test consists of the Sphinx run in which the module black boxes should be resolved (with the flatten option) for all types of diagrams. The example uses the full adder circuit, which consists of two half adder modules. 

> In order to get the possibility of checking the output HTMLs, I created the next Travis CI job. The job generates the HTMLs from all test runs, converts them to the single HTML file using [monolith](https://github.com/Y2Z/monolith) and adds them to the GitHub Pages. The Travis setup requires GitHub token with the `public_repo` access rights. The token should be added as a Travis environment variable with the  `GITHUB_PAGES_TOKEN` name.
> 
> Preview of the GitHub pages setup can be found here:
> https://rw1nkler.github.io/sphinxcontrib-verilog-diagrams/

_The GitHub Pages functionality has been moved to #58_ 


Here is the flatten test preview:
https://rw1nkler.github.io/sphinxcontrib-verilog-diagrams/test_flatten.html

![test_flatten](https://user-images.githubusercontent.com/52699314/91619122-7f615580-e98c-11ea-8d0d-47b585242e42.png)


Resolves: https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams/issues/3

------------

#52 should be merged first