### PR TITLE
Small cleanup of Makefile + setup.py 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: minimal
 
+git:
+  depth: false
+
 before_install:
     - make env
     - source env/conda/bin/activate sphinxcontrib-hdl-diagrams

--- a/setup.py
+++ b/setup.py
@@ -52,14 +52,14 @@ install_requires = [
 setup(
     name='sphinxcontrib-hdl-diagrams',
     version=__version__,
-    description='Generate diagrams from HDL in Sphinx.',
+    author="SymbiFlow Authors",
+    author_email="symbiflow@lists.librecores.org",
+    license="Apache 2.0",
+    description="Generate diagrams from HDL in Sphinx.",
     long_description=readme,
     long_description_content_type="text/x-rst",
-    author="The SymbiFlow Authors",
-    author_email='symbiflow@lists.librecores.org',
     url='https://github.com/SymbiFlow/sphinxcontrib-hdl-diagrams',
     packages=find_packages(),
-    license="Apache 2.0",
     keywords='Verilog nMigen RTLIL yosys HDL sphinx sphinx-extension netlistsvg FPGA',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Makes sphinxcontrib-hdl-diagrams Makefile / setup.py closer to [sphinx-verilog-domain](https://github.com/SymbiFlow/sphinx-verilog-domain) versions (after https://github.com/SymbiFlow/sphinx-verilog-domain/pull/20 is merged).