### PR TITLE
travis: Making configuration closer to sphinx-verilog-domain.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ git:
   depth: false
 
 before_install:
-    - make env
-    - source env/conda/bin/activate sphinxcontrib-hdl-diagrams
+  - make version
+
+install:
+  - make env
+  - source env/conda/bin/activate sphinxcontrib-hdl-diagrams
 
 stages:
     - name:
@@ -55,10 +58,8 @@ jobs:
 
     - stage: Deploy
       name: "PyPI"
-      before_install: null
+      install: null
       before_deploy:
-        - make clean
-        - make sphinxcontrib_hdl_diagrams/version.py
         - sudo ln -sf /usr/bin/python3 /usr/bin/python
       deploy:
         provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,15 @@ include third_party/make-env/conda.mk
 # Create a version.py file
 VERSION_PY = sphinxcontrib_hdl_diagrams/version.py
 $(VERSION_PY):
-	echo "__version__ = '$$(git describe | sed -e's/v\([0-9]\+\)\.\([0-9]\+\)-\([0-9]\+\)-g[0-9a-f]\+/\1.\2.post\3/')'" > $@
+	@echo "__version__ = '$$(git describe | sed -e's/v\([0-9]\+\)\.\([0-9]\+\)-\([0-9]\+\)-g[0-9a-f]\+/\1.\2.post\3/')'" > $@
 
 .PHONY: $(VERSION_PY)
 
 version:
-	$(MAKE) $(VERSION_PY)
+	@if $$(git rev-parse --is-shallow-repository); then git fetch --unshallow; fi
+	git fetch origin --tags
+	@$(MAKE) $(VERSION_PY)
+	@cat $(VERSION_PY)
 
 version-clean:
 	rm -f $(VERSION_PY)


### PR DESCRIPTION
 * Expand `make version` and run on deploy.

   Make sure tags are available and the repository isn't shallow
   (required to generate a valid git-describe output).

 * Move `make env` into the `install:` step.

   `before_install` runs the git commands (and thus should run on deploy as
   well as build).

   `install` sets up the conda environment, installs local packages, etc.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>