### PR TITLE
Remove unused imports.

### DIFF
--- a/sphinxcontrib_hdl_diagrams/__init__.py
+++ b/sphinxcontrib_hdl_diagrams/__init__.py
@@ -42,7 +42,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
-from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
+from sphinx.util.osutil import ensuredir
 
 if False:
     # For type annotation


### PR DESCRIPTION
Fixes #75 (as `ENOENT` has been removed from upstream Sphinx).

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>