### PR TITLE
Remove `file:` usage in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 - sphinx
 - yosys
 - pip:          # Packages installed from PyPI
-  - -r file:requirements.txt
-  - -r file:docs/requirements.txt
+  - -r requirements.txt
+  - -r docs/requirements.txt
   - .
   - compat/.


### PR DESCRIPTION
pip broke support for it a while ago.

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>