### PR TITLE
Specify `build` config.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,5 +29,10 @@ sphinx:
 formats:
  - htmlzip
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "miniconda3-4.7"
+
 conda:
   environment: environment.yml


### PR DESCRIPTION
https://blog.readthedocs.com/use-build-os-config/

Fixes #86.