### PR TITLE
Set language to english.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ version = release
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Fixes;
```
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
```