### PR TITLE
docs: update pip install to use sphinxcontrib-verilog-diagrams

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,13 +46,13 @@ Python 3.5+ is required.
 
 .. code-block::
 
-   pip install sphinxcontrib-hdl-diagrams
+   pip install sphinxcontrib-verilog-diagrams
 
 Or,
 
 .. code-block::
 
-   python3 -m pip install sphinxcontrib-hdl-diagrams
+   python3 -m pip install sphinxcontrib-verilog-diagrams
 
 Sphinx Integration
 ^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,13 +29,13 @@ Python 3.5+ is required.
 
 .. code-block:: bash
 
-   pip install sphinxcontrib-hdl-diagrams
+   pip install sphinxcontrib-verilog-diagrams
 
 Or,
 
 .. code-block:: bash
 
-   python3 -m pip install sphinxcontrib-hdl-diagrams
+   python3 -m pip install sphinxcontrib-verilog-diagrams
 
 Sphinx integration
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I'm unsure why the pip module is called sphinxcontrib-verilog-diagrams and elsewhere sphinx_hdl_diagrams is used. Historical resasons?

Anyway, now docs match what I find on pypi:

![image](https://github.com/SymbiFlow/sphinxcontrib-hdl-diagrams/assets/2798822/f4044acb-7405-4804-8c5d-1c2d6eea79e4)
